### PR TITLE
Display score in correct location

### DIFF
--- a/src/NPacMan.UI/BoardRenderer.cs
+++ b/src/NPacMan.UI/BoardRenderer.cs
@@ -147,9 +147,11 @@ namespace NPacMan.UI
         {
             _scoreBoard.RenderStatic(g);
             _scoreBoard.RenderScores(g, game.Score, 0, 1000);
-            _scoreBoard.RenderLivesBonus(g, game.Lives, game.Height - 1);
-//            g.DrawString($"Score : {game.Score}", _scoreFont, Brushes.White, 0, 0);
-            //          g.DrawString($"Lives : {game.Lives}", _scoreFont, Brushes.White, 0,Sprites.PixelGrid);
+        }
+
+        public void RenderLives(Graphics g, NPacMan.Game.Game game)
+        {
+            _scoreBoard.RenderLivesBonus(g, game.Lives);
         }
     }
 }

--- a/src/NPacMan.UI/Form1.cs
+++ b/src/NPacMan.UI/Form1.cs
@@ -56,12 +56,19 @@ namespace NPacMan.UI
                 using var gameBuffer = new Bitmap(_game.Width * Sprites.PixelGrid, (_game.Height + 5) * Sprites.PixelGrid);
                 {
                     var g = Graphics.FromImage(gameBuffer);
+                    
+                    _boardRenderer.RenderScore(g, _game);
 
+                    g.TranslateTransform(0, 3 * Sprites.PixelGrid);
                     _boardRenderer.RenderWalls(g, _game);
                     _boardRenderer.RenderCoins(g, _game);
                     _boardRenderer.RenderPacMan(g, _game);
-                    _boardRenderer.RenderScore(g, _game);
                     _boardRenderer.RenderGhosts(g, _game);
+                    g.ResetTransform();
+
+                    g.TranslateTransform(0, (2 + _game.Height) * Sprites.PixelGrid);
+                    _boardRenderer.RenderLives(g, _game);
+                    g.ResetTransform();
                 }
                 {
                     var g = screenBuffer.Graphics;

--- a/src/NPacMan.UI/ScoreBoard.cs
+++ b/src/NPacMan.UI/ScoreBoard.cs
@@ -30,12 +30,12 @@ namespace NPacMan.Game
             RenderString(g, high.ToString().PadLeft(6), 11, 1);
         }
 
-        public void RenderLivesBonus(Graphics g, int lives, int boardHeight)
+        public void RenderLivesBonus(Graphics g, int lives)
         {
             var lifeSprite = _sprites.PacMan(Direction.Left, 1, false);
             // The large sprite in the score board span two grid squares
             // rather than being central to one. Adding 0.5 grid square to compensate
-            var ypos = boardHeight * Sprites.PixelGrid + Sprites.PixelGrid / 2;
+            var ypos = Sprites.PixelGrid / 2;
             for (int i = 0; i < lives; i++)
             {
                 _sprites.RenderSprite(g, (i * Sprites.PixelGrid * 2) + 2 * Sprites.PixelGrid + Sprites.PixelGrid / 2, ypos,  lifeSprite);


### PR DESCRIPTION
I think we lost this change somewhere.

The idea is that the score board,  game board and available lives all think they are drawing relative to 0,0

The calling code then defines where 0,0 really is on the screen.