### PR TITLE
Move code from statement to actions class

### DIFF
--- a/src/NPacMan.Game/Actions.cs
+++ b/src/NPacMan.Game/Actions.cs
@@ -8,19 +8,66 @@ namespace NPacMan.Game
 {
     internal static class Actions
     {
-        public static void ShowGhosts(GameState gameState)
+        public static void BeginDying(GameState gameState, GameNotifications gameNotifications)
         {
+            gameState.HideGhosts();
+            gameNotifications.Publish(GameNotification.Dying);
+        }
+
+        public static void BeginRespawning(GameNotifications gameNotifications)
+        {
+            gameNotifications.Publish(GameNotification.Respawning);
+        }
+
+        public static void CompleteRespawning(GameState gameState)
+        {
+            MoveGhostsHome(gameState);
+            MovePacManHome(gameState);
             gameState.ShowGhosts();
         }
 
-        public static void HideGhosts(GameState gameState)
+        public static void SetupGame(GameState gameState, DateTime now, GameNotifications gameNotifications)
         {
-            gameState.HideGhosts();
+            gameState.RecordLastTick(now);
+            MoveGhostsHome(gameState);
+            gameState.ShowGhosts();
+            gameNotifications.Publish(GameNotification.Beginning);
         }
 
-        private static IEnumerable<Ghost> GhostsCollidedWithPacMan(GameState gameState)
+        public static void CoinEaten(GameState gameState, CellLocation coinLocation, GameNotifications gameNotifications)
         {
-            return gameState.Ghosts.Values.Where(ghost => ghost.Location == gameState.PacMan.Location);
+            gameState.RemoveCoin(coinLocation);
+            gameState.IncreaseScore(10);
+            gameNotifications.Publish(GameNotification.EatCoin);
+        }
+
+        public static void PowerPillEaten(GameState gameState, CellLocation powerPillLocation, GameNotifications gameNotifications)
+        {
+            gameState.IncreaseScore(50);
+            gameNotifications.Publish(GameNotification.EatPowerPill);
+            MakeGhostsEdible(gameState);
+            gameState.RemovePowerPill(powerPillLocation);
+        }
+
+        public static void GhostEaten(GameState gameState, Ghost ghost, Game game)
+        {
+            SendGhostHome(gameState, ghost);
+            IncreaseScoreAfterEatingGhost(gameState, game);
+            MakeGhostNotEdible(gameState, ghost);
+        }
+
+        public static void EatenByGhost(GameState gameState)
+        {
+            gameState.DecreaseLives();
+        }
+
+        public static void ChangeDirection(IGameSettings gameSettings, GameState gameState, Direction direction)
+        {
+            var nextSpace = gameState.PacMan.Location + direction;
+            if (!gameSettings.Walls.Contains(nextSpace))
+            {
+                gameState.ChangeDirectionOfPacMan(direction);
+            }
         }
 
         public static void ScatterGhosts(GameState gameState)
@@ -33,31 +80,9 @@ namespace NPacMan.Game
             gameState.ApplyToGhosts(ghost => ghost.Chase());
         }
 
-        public static void MoveGhostsHome(GameState gameState)
-        {
-            gameState.ApplyToGhosts(ghost => ghost.SetToHome());
-        }
-
-        public static void MakeGhostsEdible(GameState gameState)
-        {
-            gameState.ApplyToGhosts(ghost => ghost.SetToEdible());
-        }
-
         public static void MakeGhostsNotEdible(GameState gameState)
         {
             gameState.ApplyToGhosts(ghost => ghost.SetToNotEdible());
-        }
-
-         public static void MakeGhostNotEdible(GameState gameState,  Ghost ghostToUpdate)
-        {
-            gameState.ApplyToGhost(ghost => ghost.SetToNotEdible(), ghostToUpdate);
-        }
-
-        public static void MovePacManHome(GameState gameState) => gameState.MovePacManHome();
-
-        public static void SendGhostHome(GameState gameState, Ghost ghostToUpdate)
-        {
-            gameState.ApplyToGhost(ghost => ghost.SetToHome(), ghostToUpdate);
         }
 
         public async static Task MovePacMan(IGameSettings gameSettings, GameState gameState, BehaviorContext<GameState, Tick> context, GameStateMachine gameStateMachine)
@@ -102,30 +127,38 @@ namespace NPacMan.Game
             }
         }
 
-        internal static void IncreaseScoreAfterEatingGhost(GameState gameState, Game game)
+        private static IEnumerable<Ghost> GhostsCollidedWithPacMan(GameState gameState)
+        {
+            return gameState.Ghosts.Values.Where(ghost => ghost.Location == gameState.PacMan.Location);
+        }
+
+        private static void IncreaseScoreAfterEatingGhost(GameState gameState, Game game)
         {
             var numberOfInEdibleGhosts = game.Ghosts.Values.Count(g => !g.Edible);
             var increaseInScore = (int)Math.Pow(2, numberOfInEdibleGhosts) * 200;
             gameState.IncreaseScore(increaseInScore);
         }
 
-        public static void RemoveCoin(GameState gameState, CellLocation location)
+        private static void MakeGhostNotEdible(GameState gameState, Ghost ghostToUpdate)
         {
-            gameState.RemoveCoin(location);
+            gameState.ApplyToGhost(ghost => ghost.SetToNotEdible(), ghostToUpdate);
         }
 
-        public static void RemovePowerPill(GameState gameState, CellLocation location)
+        private static void MovePacManHome(GameState gameState) => gameState.MovePacManHome();
+
+        private static void SendGhostHome(GameState gameState, Ghost ghostToUpdate)
         {
-            gameState.RemovePowerPill(location);
+            gameState.ApplyToGhost(ghost => ghost.SetToHome(), ghostToUpdate);
         }
 
-        public static void ChangeDirection(IGameSettings gameSettings, GameState gameState, Direction direction)
+        private static void MoveGhostsHome(GameState gameState)
         {
-            var nextSpace = gameState.PacMan.Location + direction;
-            if (!gameSettings.Walls.Contains(nextSpace))
-            {
-                gameState.ChangeDirectionOfPacMan(direction);
-            }
+            gameState.ApplyToGhosts(ghost => ghost.SetToHome());
+        }
+
+        private static void MakeGhostsEdible(GameState gameState)
+        {
+            gameState.ApplyToGhosts(ghost => ghost.SetToEdible());
         }
     }
 }

--- a/src/NPacMan.Game/GameStateMachine.cs
+++ b/src/NPacMan.Game/GameStateMachine.cs
@@ -1,4 +1,5 @@
 ﻿using Automatonymous;
+using System;
 
 namespace NPacMan.Game
 {
@@ -15,10 +16,7 @@ namespace NPacMan.Game
 
             Initially(
                 When(Tick)
-                    .Then(context => context.Instance.RecordLastTick(context.Data.Now))
-                    .Then(context => Actions.MoveGhostsHome(context.Instance))
-                    .Then(context => Actions.ShowGhosts(context.Instance))
-                    .Then(context => gameNotifications.Publish(GameNotification.Beginning))
+                    .Then(context => Actions.SetupGame(context.Instance, context.Data.Now, gameNotifications))
                     .TransitionTo(Scatter));
 
             WhenEnter(Scatter,
@@ -55,28 +53,20 @@ namespace NPacMan.Game
                     .ThenAsync(async context => await Actions.MoveGhosts(game, context.Instance, context, this))
                     .ThenAsync(async context => await Actions.MovePacMan(settings, context.Instance, context, this)),
                 When(CoinCollision)
-                    .Then(context => Actions.RemoveCoin(context.Instance, context.Data.Location))
-                    .Then(context => context.Instance.IncreaseScore(10))
-                    .Then(context => gameNotifications.Publish(GameNotification.EatCoin)),
+                    .Then(context => Actions.CoinEaten(context.Instance, context.Data.Location, gameNotifications)),
                 When(PowerPillCollision)
-                    .Then(context => context.Instance.IncreaseScore(50))
-                    .Then(context => gameNotifications.Publish(GameNotification.EatPowerPill))
-                    .Then(context => Actions.MakeGhostsEdible(context.Instance))
-                    .Then(context => Actions.RemovePowerPill(context.Instance, context.Data.Location))
+                    .Then(context => Actions.PowerPillEaten(context.Instance, context.Data.Location, gameNotifications))
                     .TransitionTo(Frightened),
                 When(GhostCollision)
                     .IfElse(x => x.Data.Ghost.Edible,
-                    binder => binder.Then(context => Actions.SendGhostHome(context.Instance, context.Data.Ghost))
-                                    .Then(context => Actions.IncreaseScoreAfterEatingGhost(context.Instance, game))
-                                    .Then(context => Actions.MakeGhostNotEdible(context.Instance, context.Data.Ghost)),
-                    binder => binder.Then(context => context.Instance.DecreaseLives())
+                    binder => binder.Then(context => Actions.GhostEaten(context.Instance, context.Data.Ghost, game)),
+                    binder => binder.Then(context => Actions.EatenByGhost(context.Instance))
                                     .TransitionTo(Dying))); 
 
             WhenEnter(Dying,
                        binder => binder
-                                .Then(context => Actions.HideGhosts(context.Instance))
-                                .Then(context => context.Instance.ChangeStateIn(4))
-                                .Then(context => gameNotifications.Publish(GameNotification.Dying)));
+                                .Then(context => Actions.BeginDying(context.Instance, gameNotifications))
+                                .Then(context => context.Instance.ChangeStateIn(4)));
 
             During(Dying,
                 When(Tick, context => context.Data.Now >= context.Instance.TimeToChangeState)
@@ -87,14 +77,11 @@ namespace NPacMan.Game
             WhenEnter(Respawning,
                        binder => binder
                                 .Then(context => context.Instance.ChangeStateIn(4))
-                                .Then(context => gameNotifications.Publish(GameNotification.Respawning)));
+                                .Then(context => Actions.BeginRespawning(gameNotifications)));
 
             During(Respawning,
                 When(Tick, context => context.Data.Now >= context.Instance.TimeToChangeState)
-                    .Then(context => context.Instance.ChangeStateIn(4))
-                    .Then(context => Actions.MoveGhostsHome(context.Instance))
-                    .Then(context => Actions.MovePacManHome(context.Instance))
-                    .Then(context => Actions.ShowGhosts(context.Instance))
+                    .Then(context => Actions.CompleteRespawning(context.Instance))
                     .TransitionTo(GhostChase));
 
             During(Dead, Ignore(Tick));


### PR DESCRIPTION
The game state engine now only really contains code to do with changing state,  and calls to methods in the Actions class

1st half of the actions class now contains methods which are called by the statement machine.

2nd half contains private helper methods.

